### PR TITLE
Say "syntax highlighting" instead of just "syntax"

### DIFF
--- a/runtime/help/options.md
+++ b/runtime/help/options.md
@@ -198,7 +198,7 @@ Here are the options that you can set:
 
     default value: `false`
 
-* `syntax`: turns syntax on or off.
+* `syntax`: turns syntax highlighting on or off.
 
 	default value: `true`
 


### PR DESCRIPTION
The description of the `syntax` option in the options help file should say
> turns syntax highlighting on or off

instead of

> turns syntax on or off

Syntax cannot be turned off and on.